### PR TITLE
fix jupyter user group

### DIFF
--- a/nixos/modules/services/development/jupyter/default.nix
+++ b/nixos/modules/services/development/jupyter/default.nix
@@ -188,7 +188,7 @@ in {
     })
     (mkIf (cfg.enable && (cfg.user == "jupyter")) {
       users.extraUsers.jupyter = {
-        extraGroups = [ cfg.group ];
+        group = [ cfg.group ]; # Required since a user's group attribute cannot be unset as this is unsafe.
         home = "/var/lib/jupyter";
         createHome = true;
         isSystemUser = true;


### PR DESCRIPTION
Looks like nixpkgs changed it since it was last updated, they made groups unsafe to be left unset which doesn't get bypassed when adding extraGroups so we need to specify the user's group.